### PR TITLE
Potential fix for code scanning alert no. 5: Missing origin verification in `postMessage` handler

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -56,7 +56,12 @@ self.addEventListener('activate', async (event) => {
 
 // listen for messages from the client
 self.addEventListener('message', (event) => {
-    console.log('[SW] message: ' + event.data);
+    const trustedOrigins = ['https://www.example.com']; // Add trusted origins here
+    if (trustedOrigins.includes(event.origin)) {
+        console.log('[SW] message from trusted origin: ' + event.data);
+    } else {
+        console.warn('[SW] message from untrusted origin: ' + event.origin);
+    }
 });
 
 //


### PR DESCRIPTION
Potential fix for [https://github.com/wottreng/Race_Tracker/security/code-scanning/5](https://github.com/wottreng/Race_Tracker/security/code-scanning/5)

To fix the issue, the `message` event handler should verify the `origin` of the incoming message before processing it. This involves checking the `event.origin` property against a list of trusted origins. If the origin is not trusted, the handler should ignore the message. 

The fix will involve:
1. Adding a conditional check for `event.origin` in the `message` event handler.
2. Defining a list of trusted origins (e.g., as a constant or configuration variable).
3. Ensuring that only messages from trusted origins are logged or processed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
